### PR TITLE
Adding documentation to load function and adding kwargs to update functions

### DIFF
--- a/dcarte/load.py
+++ b/dcarte/load.py
@@ -20,19 +20,28 @@ sep = os.sep
 
 @timer('Loading')
 def load(dataset:str,domain:str,**kwargs):
-    """load [summary]
+    """load a dataset from the domain given. Note that 
+    update=True and reload=True have different behaviour, 
+    please read the descriptions of the arguments to understand what
+    is appropriate for your use-case.
 
-    [extended_summary]
-
+    Example:
+    
+    >>> movement_data = dcarte.load('motion', 'base')
+    
     Args:
-        dataset (str): [description]
-        domain (str): [description]
-
+        dataset (str): The name of the dataset to load.
+        domain (str): The domain that the dataset is contained within.
+    KwArgs:
+        since (str): The date to load the data from. The format should be '[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]' or '[YYYY]-[MM]-[DD]'. Defaults to '2019-04-01'.
+        until (str): The date to load the data to. The format should be '[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]' or '[YYYY]-[MM]-[DD]'. If the date given is sooner than the data downloaded, the data will not update unless update=True. Defaults to the current date and time.
+        update (bool): Whether to update the data when loading, by downloading the recent data from the server and re-running the script that produces the given domain. Defaults to False.
+        reload (bool): Whether to re-download all data from the server and to re-run the script that feeds and produces this dataset. Defaults to False.
+        reapply (bool): Whether to re-run the function that produces this dataset. This will not re-run the functions that produce the datasets that feed this one. Defaults to False.
     Raises:
-        Exception: [description]
-
+        Exception: If the dataset is not contained in the domain. 
     Returns:
-        [type]: [description]
+        pandas.DataFrame: The loaded dataset.
     """
     dataset,domain = dataset.lower(),domain.lower()
     cfg = get_config()

--- a/dcarte/update.py
+++ b/dcarte/update.py
@@ -9,7 +9,21 @@ sep = os.sep
 cfg = get_config()
 NOW = date2iso(str(dt.datetime.now()))
 
-def update_raw():
+def update_raw(**kwargs):
+    """update_raw updates the raw data
+    stored locally.
+
+    To re-download all of the raw data, and overwrite the current
+    local datasets for that domain, you would use: 
+
+    >>> dcarte.update_raw(reload=True)
+
+    Args:
+        kwargs : Keyword arguments are passed to the dcarte.load function. update=True is already passed.
+
+    Returns:
+        None
+    """
     print("THIS FUNCTION MAY TAKE LONG")
     datasets = {}   
     files = list(Path(cfg['data']).rglob('*.parquet'))
@@ -17,11 +31,26 @@ def update_raw():
         datasets[i] = dict(dataset = file.stem,domain = file.parent.stem)
     datasets = pd.DataFrame(datasets).T
     for _,row in datasets.query('domain in ["raw","lookup"]').iterrows():
-        _ = load(row.dataset,row.domain,update=True)
+        _ = load(row.dataset,row.domain,update=True, **kwargs)
         
         
         
-def update_domain(domain ="base"):
+def update_domain(domain ="base", **kwargs):
+    """update_raw updates the raw data
+    stored locally.
+
+    To re-download all of the data for DOMAIN, and overwrite the current
+    local datasets for that domain, you would use: 
+
+    >>> dcarte.update_domain(domain=DOMAIN, reload=True)
+
+    Args:
+        domain (str): The name of the domain to update.
+        kwargs : Keyword arguments are passed to the dcarte.load function. update=True is already passed.
+
+    Returns:
+        None
+    """
     print("THIS FUNCTION MAY TAKE LONG")
     datasets = {}   
     files = list(Path(cfg['data']).rglob('*.parquet'))
@@ -29,4 +58,4 @@ def update_domain(domain ="base"):
         datasets[i] = dict(dataset = file.stem,domain = file.parent.stem)
     datasets = pd.DataFrame(datasets).T
     for _,row in datasets.query('domain in @domain').iterrows():
-        _ = load(row.dataset,row.domain,update=True)
+        _ = load(row.dataset,row.domain,update=True, **kwargs)


### PR DESCRIPTION
Adding documentation to the dcarte.load function and allowing for kwargs to be passed from the update functions to the load functions. The allows you to specify reload=True in the update functions to re-download all of a domain's data. Let me know if the documentation isn't in line with what you usually write, I'm used to the numpy formatting.